### PR TITLE
fix: hero rendering

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,11 +4,13 @@ Welcome to cpp-linter! This guide will help you integrate C/C++ linting into you
 
 ## Choose Your Integration
 
+<!-- markdownlint-disable MD033 -->
+
 Select the method that best fits your development workflow:
 
 <div class="grid cards" markdown>
 
--   :material-github: **GitHub Actions**
+- :material-github: **GitHub Actions**
 
     ---
 
@@ -18,8 +20,7 @@ Select the method that best fits your development workflow:
 
     [Get started with GitHub Actions →](https://cpp-linter.github.io/cpp-linter-action/){ .md-button .md-button--primary }
 
-
--   :material-git: **Pre-commit Hooks**
+- :material-git: **Pre-commit Hooks**
 
     ---
 
@@ -28,9 +29,8 @@ Select the method that best fits your development workflow:
     **Perfect for:** Catching issues before commits, local enforcement
 
     [Get started with pre-commit →](https://github.com/cpp-linter/cpp-linter-hooks){ .md-button .md-button--primary }
-    
 
--   :fontawesome-brands-python: **Command Line**
+- :fontawesome-brands-python: **Command Line**
 
     ---
 
@@ -40,7 +40,7 @@ Select the method that best fits your development workflow:
 
     [Get started with cpp-linter package →](https://cpp-linter.github.io/cpp-linter/){ .md-button .md-button--primary }
 
--   :simple-rust: **Command Line (Rust)**
+- :simple-rust: **Command Line (Rust)**
 
     ---
 
@@ -56,7 +56,7 @@ Select the method that best fits your development workflow:
 
 <div class="grid cards" markdown>
 
--   :fontawesome-brands-github: **clang-tools-static-binaries**
+- :fontawesome-brands-github: **clang-tools-static-binaries**
 
     ---
 
@@ -64,8 +64,7 @@ Select the method that best fits your development workflow:
 
     [Download from →](https://github.com/cpp-linter/clang-tools-static-binaries){ .md-button .md-button--primary }
 
-
--   :fontawesome-brands-docker: **clang-tools-docker**
+- :fontawesome-brands-docker: **clang-tools-docker**
 
     ---
 
@@ -73,8 +72,7 @@ Select the method that best fits your development workflow:
 
     [Download from →](https://github.com/cpp-linter/clang-tools-docker){ .md-button .md-button--primary }
 
-
--   :fontawesome-brands-python: **clang-tools-wheels**
+- :fontawesome-brands-python: **clang-tools-wheels**
 
     ---
 
@@ -84,13 +82,11 @@ Select the method that best fits your development workflow:
 
 </div>
 
-
-
 ## Easy Installation
 
 <div class="grid cards" markdown>
 
--   :fontawesome-brands-python: **clang-tools-pip**
+- :fontawesome-brands-python: **clang-tools-pip**
 
     ---
 
@@ -98,7 +94,7 @@ Select the method that best fits your development workflow:
 
     [Get started with clang-tools CLI →](https://cpp-linter.github.io/clang-tools-pip/){ .md-button .md-button--primary }
 
--   :fontawesome-brands-python: **clang-tools-asdf**
+- :fontawesome-brands-python: **clang-tools-asdf**
 
     ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,21 @@ hide:
   - toc
 ---
 
+<!-- markdownlint-disable MD041 MD033 MD036 -->
+
+<style>
+  /* this must be embedded in the page because
+     it removes the gap between header and hero */
+  .md-main__inner {
+    margin-top: 0;
+  }
+  .md-content__inner {
+    padding-top: 0;
+  }
+  .md-content__inner::before {
+    height: 0;
+  }
+</style>
 <div class="hero" markdown>
 
 # C/C++ linting that simply works
@@ -22,19 +37,19 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-chart-line: **Built in Open Source**
+- :material-chart-line: **Built in Open Source**
 
     ---
 
     Open-source and MIT-licensed. Bringing contributors together to empower impactful C/C++ lint projects in open source and beyond.
 
--   :material-cog: **Zero Configuration**
+- :material-cog: **Zero Configuration**
 
     ---
 
     Works out of the box with sensible defaults. Advanced users can customize every aspect to match their coding standards.
 
--   :material-devices: **Works Everywhere**
+- :material-devices: **Works Everywhere**
 
     ---
 
@@ -138,7 +153,15 @@ hide:
         - id: clang-format
             args: [--style=Google] # Other coding style: LLVM, GNU, Chromium, Microsoft, Mozilla, WebKit.
         - id: clang-tidy
-            args: [--checks='boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*']
+            args:
+              - --checks='boost-*
+              - bugprone-*
+              - performance-*
+              - readability-*
+              - portability-*
+              - modernize-*
+              - clang-analyzer-*
+              - cppcoreguidelines-*'
     ```
 
 === "Command Line"

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -2,15 +2,21 @@ th {
     background-color: var(--md-default-fg-color--lightest);
 }
 
+:root > * {
+    --cpp-linter-logo-color-green: #40b385;
+    --cpp-linter-logo-color-yellow: #ffc20a;
+}
+
 /* Hero section styling */
 .hero {
     text-align: center;
     padding: 4rem 0;
-    background: linear-gradient(135deg, var(--md-primary-fg-color) 0%, var(--md-accent-fg-color) 100%);
-    background-size: 200% 200%;
-    animation: gradientShift 8s ease infinite;
-    color: white;
-    margin: -1.5rem -1.5rem 3rem -1.5rem;
+    /* background: linear-gradient(135deg, var(--md-primary-fg-color) 0%, var(--cpp-linter-logo-color-green) 100%); */
+    /* background-size: 200% 200%; */
+    /* animation: gradientShift 8s ease infinite; */
+    background: var(--md-primary-fg-color);
+    color: var(--md-primary-bg-color);
+    margin: 0 -1em 3rem -1em;
     border-radius: 0 0 1rem 1rem;
 }
 
@@ -19,15 +25,37 @@ th {
     font-weight: 700;
     margin-bottom: 1rem;
     text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    text-align: center;
+    color: unset;
 }
 
 .hero p {
     font-size: 1.2rem;
     margin-bottom: 2rem;
     opacity: 0.9;
-    max-width: 600px;
+    width: 65%;
     margin-left: auto;
     margin-right: auto;
+}
+
+.hero .md-button:hover {
+    border: 2px solid black;
+}
+
+.hero .md-button {
+    background: var(--cpp-linter-logo-color-green);
+    color: black;
+    border: none;
+}
+
+.hero .md-button:hover {
+    background: var(--cpp-linter-logo-color-yellow);
+    color: black;
+    border: none;
+}
+
+.md-typeset .md-button:hover {
+    color: black;
 }
 
 @keyframes gradientShift {
@@ -182,19 +210,6 @@ th {
     .stat strong {
         font-size: 1.5rem;
     }
-}
-
-.md-header {
-    background-color: #4051b5;
-}
-
-/* Make navigation tabs match header color */
-.md-tabs {
-    background-color: #4051b5;
-}
-
-.md-tabs__list {
-    background-color: #4051b5;
 }
 
 /* Ensure tab items have proper contrast */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: "cpp-linter"
 site_description: "Documentation for the cpp-linter organization."
 site_url: "https://cpp-linter.github.io/"
 repo_url: https://github.com/cpp-linter
-
+repo_name: "cpp-linter"
 copyright: "© 2021-2025, cpp-linter"
 
 nav:
@@ -11,6 +11,8 @@ nav:
   - Discussion: discussion.md
   # - Blog:
   #     - blog/index.md
+exclude_docs: |
+  blog/**
 
 theme:
   name: material
@@ -35,7 +37,7 @@ theme:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: blue
+      primary: indigo
       accent: cyan
       toggle:
         icon: material/lightbulb-outline
@@ -44,7 +46,7 @@ theme:
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: blue
+      primary: indigo
       accent: cyan
       toggle:
         icon: material/lightbulb


### PR DESCRIPTION
resolves #3 

* Better color choice for anti-aliasing.
* Better size and positioning for mobile and desktop.
* Update mkdocs.yml config to silence warnings about unused documents (`blog/**`)
* Update `repo_name` in mkdocs.yml to display GitHub org name instead of the generic default ("Github")
* Disable markdownlint warnings as needed.