### PR TITLE
[codex] Improve docs onboarding

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,11 +2,26 @@
 
 Welcome to cpp-linter! This guide will help you integrate C/C++ linting into your workflow quickly and efficiently.
 
+## What is cpp-linter?
+
+cpp-linter connects the standard LLVM linting tools, `clang-format` and `clang-tidy`, to the places where C/C++ projects need checks: pull requests, pre-commit hooks, local scripts, and CI jobs.
+
+- `clang-format` checks formatting against a named style or your `.clang-format` file.
+- `clang-tidy` runs static-analysis and modernization checks, usually configured by `.clang-tidy`.
+- cpp-linter packages those tools into integrations with consistent defaults, reporting, and failure controls.
+
 ## Choose Your Integration
 
 <!-- markdownlint-disable MD033 -->
 
 Select the method that best fits your development workflow:
+
+| Use case | Recommended entry point |
+| --- | --- |
+| GitHub pull request checks | [cpp-linter-action](https://cpp-linter.github.io/cpp-linter-action/) |
+| Local checks before commits | [cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks) |
+| Custom scripts or CI jobs | [cpp-linter CLI](https://cpp-linter.github.io/cpp-linter/) |
+| High-performance local runs | [cpp-linter-rs](https://cpp-linter.github.io/cpp-linter-rs/) |
 
 <div class="grid cards" markdown>
 
@@ -51,6 +66,41 @@ Select the method that best fits your development workflow:
     [Get started with cpp-linter-rs →](https://cpp-linter.github.io/cpp-linter-rs/){ .md-button .md-button--primary }
 
 </div>
+
+## Minimal Examples
+
+=== "GitHub Actions"
+
+    ```yaml
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cpp-linter/cpp-linter-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file
+          tidy-checks: ""
+    ```
+
+=== "Pre-commit"
+
+    ```yaml
+    repos:
+      - repo: https://github.com/cpp-linter/cpp-linter-hooks
+        rev: v1.2.0
+        hooks:
+          - id: clang-format
+            args: [--style=file]
+          - id: clang-tidy
+            args: [--checks=-*,bugprone-*,performance-*,readability-*]
+    ```
+
+=== "Command Line"
+
+    ```bash
+    pip install cpp-linter
+    cpp-linter --style=file --tidy-checks='-*,bugprone-*,performance-*,readability-*' src/
+    ```
 
 ## Clang Tools Distribution
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,7 @@ template: home.html
 title: C/C++ Linting
 ---
 
-<!-- markdownlint-disable MD041 MD033 MD036 MD025 -->
-
-# C/C++ Linting
-
-## Everything you need for linting C/C++ code
+<!-- markdownlint-disable MD041 MD033 MD036 -->
 
 <div class="grid cards" markdown>
 
@@ -34,21 +30,13 @@ title: C/C++ Linting
 
 </div>
 
-<div class="grid" markdown>
-
-</div>
-
-## Trusted by developers worldwide
+## Used across open-source projects
 
 <div class="trusted-by" markdown>
 
-**Join thousands of developers and organizations using cpp-linter in production**
+Examples of public GitHub organizations and projects where cpp-linter usage has been seen. This list is a discovery aid, not an endorsement.
 
 <div class="logo-grid">
-  <div class="logo-item">
-    <img src="https://github.com/microsoft.png" alt="Microsoft" title="Microsoft">
-    <span>Microsoft</span>
-  </div>
   <div class="logo-item">
     <img src="https://github.com/apache.png" alt="Apache" title="Apache">
     <span>Apache</span>
@@ -94,18 +82,6 @@ title: C/C++ Linting
     <span>LedgerHQ</span>
   </div>
   <div class="logo-item">
-    <img src="https://github.com/LLNL.png" alt="LLNL" title="LLNL">
-    <span>LLNL</span>
-  </div>
-  <div class="logo-item">
-    <img src="https://github.com/cohere-ai.png" alt="cohere" title="cohere">
-    <span>cohere</span>
-  </div>
-  <div class="logo-item">
-    <img src="https://github.com/diasurgical.png" alt="Diasurgical" title="Diasurgical">
-    <span>Diasurgical</span>
-  </div>
-  <div class="logo-item">
     <img src="https://github.com/KhronosGroup.png" alt="Khronos Group" title="Khronos Group">
     <span>Khronos Group</span>
   </div>
@@ -121,30 +97,7 @@ title: C/C++ Linting
     <img src="https://github.com/Cambridge-ICCS.png" alt="Cambridge ICCS" title="Cambridge ICCS">
     <span>Cambridge ICCS</span>
   </div>
-  <div class="logo-item">
-    <img src="https://github.com/openMSL.png" alt="OpenMSL" title="OpenMSL">
-    <span>OpenMSL</span>
-  </div>
-   <div class="logo-item">
-    <img src="https://github.com/xemu-project.png" alt="Xemu Project" title="Xemu Project">
-    <span>Xemu Project</span>
-  </div>
 </div>
-
-<!-- <div class="stats-grid">
-  <div class="stat">
-    <strong>1,000+</strong>
-    <span>GitHub Users</span>
-  </div>
-  <div class="stat">
-    <strong>20K+</strong>
-    <span>Downloads/Month</span>
-  </div>
-  <div class="stat">
-    <strong>50+</strong>
-    <span>Contributors</span>
-  </div>
-</div> -->
 
 </div>
 
@@ -179,18 +132,10 @@ title: C/C++ Linting
       - repo: https://github.com/cpp-linter/cpp-linter-hooks
         rev: v1.2.0  # Use the tag or commit you want
         hooks:
-        - id: clang-format
+          - id: clang-format
             args: [--style=Google] # Other coding style: LLVM, GNU, Chromium, Microsoft, Mozilla, WebKit.
-        - id: clang-tidy
-            args:
-              - --checks='boost-*
-              - bugprone-*
-              - performance-*
-              - readability-*
-              - portability-*
-              - modernize-*
-              - clang-analyzer-*
-              - cppcoreguidelines-*'
+          - id: clang-tidy
+            args: [--checks=-*,bugprone-*,performance-*,readability-*]
     ```
 
 === "Command Line"

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -11,7 +11,7 @@ th {
 .hero {
     text-align: center;
     padding: 4rem 0;
-    background: var(--md-primary-fg-color);
+    background: linear-gradient(135deg, var(--md-primary-fg-color) 0%, var(--cpp-linter-logo-color-green) 100%);
     color: var(--md-primary-bg-color);
 }
 
@@ -44,7 +44,6 @@ th {
     background: var(--cpp-linter-logo-color-yellow);
     color: black;
     border: none;
-    border-radius: unset;
     display: inline-block;
 }
 
@@ -56,12 +55,6 @@ th {
 
 .md-typeset .md-button:hover {
     color: black;
-}
-
-@keyframes gradientShift {
-    0% { background-position: 0% 50%; }
-    50% { background-position: 100% 50%; }
-    100% { background-position: 0% 50%; }
 }
 
 /* Card enhancements */
@@ -168,32 +161,6 @@ th {
     color: var(--md-default-fg-color--light);
 }
 
-.stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 2rem;
-    padding: 0 2rem;
-}
-
-.stat {
-    text-align: center;
-}
-
-.stat strong {
-    display: block;
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--md-primary-fg-color);
-    margin-bottom: 0.5rem;
-}
-
-.stat span {
-    font-size: 0.9rem;
-    color: var(--md-default-fg-color--light);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-}
-
 /* Mobile responsiveness for trusted by section */
 @media screen and (max-width: 768px) {
     .logo-grid {
@@ -202,28 +169,9 @@ th {
         padding: 0 1rem;
     }
 
-    .stats-grid {
-        grid-template-columns: repeat(2, 1fr);
-        padding: 0 1rem;
+    .hero p {
+        width: 85%;
     }
-
-    .stat strong {
-        font-size: 1.5rem;
-    }
-}
-
-/* Ensure tab items have proper contrast */
-.md-tabs__item {
-    background-color: transparent;
-}
-
-.md-tabs__link {
-    color: rgba(255, 255, 255, 0.7);
-}
-
-.md-tabs__link--active,
-.md-tabs__link:hover {
-    color: white;
 }
 
 @media screen and (max-width: 76.2344em) {
@@ -247,164 +195,6 @@ th {
 .md-typeset .important>.admonition-title,
 .md-typeset .important>summary {
     background-color: #00b8d41a;
-}
-
-@keyframes heart {
-
-    0%,
-    40%,
-    80%,
-    to {
-        transform: scale(1)
-    }
-
-    20%,
-    60% {
-        transform: scale(1.15)
-    }
-}
-
-.md-typeset .mdx-heart {
-    animation: heart 1s infinite
-}
-
-.md-typeset .mdx-badge {
-    font-size: .85em
-}
-
-.md-typeset .mdx-badge--heart {
-    color: #ff4281;
-}
-
-.md-typeset .mdx-badge--heart.twemoji {
-    animation: heart 1s infinite
-}
-
-.md-typeset .mdx-badge--right {
-    float: right;
-    margin-left: .35em
-}
-
-[dir=ltr] .md-typeset .mdx-badge__icon {
-    border-top-left-radius: .1rem
-}
-
-[dir=rtl] .md-typeset .mdx-badge__icon {
-    border-top-right-radius: .1rem
-}
-
-[dir=ltr] .md-typeset .mdx-badge__icon {
-    border-bottom-left-radius: .1rem
-}
-
-[dir=rtl] .md-typeset .mdx-badge__icon {
-    border-bottom-right-radius: .1rem
-}
-
-.md-typeset .mdx-badge__icon {
-    background: var(--md-accent-fg-color--transparent);
-    padding: .2rem
-}
-
-.md-typeset .mdx-badge__icon:last-child {
-    border-radius: .1rem
-}
-
-[dir=ltr] .md-typeset .mdx-badge__text {
-    border-top-right-radius: .1rem
-}
-
-[dir=rtl] .md-typeset .mdx-badge__text {
-    border-top-left-radius: .1rem
-}
-
-[dir=ltr] .md-typeset .mdx-badge__text {
-    border-bottom-right-radius: .1rem
-}
-
-[dir=rtl] .md-typeset .mdx-badge__text {
-    border-bottom-left-radius: .1rem
-}
-
-.md-typeset .mdx-badge__text {
-    box-shadow: 0 0 0 1px inset var(--md-accent-fg-color--transparent);
-    padding: .2rem .3rem
-}
-
-.md-typeset .mdx-social {
-    height: min(27rem, 80vw);
-    position: relative
-}
-
-.md-typeset .mdx-social:hover .mdx-social__image {
-    background-color: #e4e4e40d
-}
-
-.md-typeset .mdx-social__layer {
-    margin-top: 4rem;
-    position: absolute;
-    transform-style: preserve-3d;
-    transition: .25s cubic-bezier(.7, 0, .3, 1)
-}
-
-.md-typeset .mdx-social__layer:hover .mdx-social__label {
-    opacity: 1
-}
-
-.md-typeset .mdx-social__layer:hover .mdx-social__image {
-    background-color: #7f7f7ffc
-}
-
-.md-typeset .mdx-social__layer:hover~.mdx-social__layer {
-    opacity: 0
-}
-
-.md-typeset .mdx-social__image {
-    box-shadow: -.25rem .25rem .5rem #0000000d;
-    transform: rotate(-40deg) skew(15deg, 15deg) scale(.7);
-    transition: all .25s
-}
-
-.md-typeset .mdx-social__image img {
-    display: block
-}
-
-.md-typeset .mdx-social__label {
-    background-color: var(--md-default-fg-color--light);
-    color: var(--md-default-bg-color);
-    display: block;
-    opacity: 0;
-    padding: .2rem .4rem;
-    position: absolute;
-    transition: all .25s
-}
-
-.md-typeset .mdx-social:hover .mdx-social__layer:nth-child(6) {
-    transform: translateY(-30px)
-}
-
-.md-typeset .mdx-social:hover .mdx-social__layer:nth-child(5) {
-    transform: translateY(-20px)
-}
-
-.md-typeset .mdx-social:hover .mdx-social__layer:nth-child(4) {
-    transform: translateY(-10px)
-}
-
-.md-typeset .mdx-social:hover .mdx-social__layer:nth-child(3) {
-    transform: translateY(0)
-}
-
-.md-typeset .mdx-social:hover .mdx-social__layer:nth-child(2) {
-    transform: translateY(10px)
-}
-
-.md-typeset .mdx-social:hover .mdx-social__layer:first-child {
-    transform: translateY(20px)
-}
-
-.md-typeset .mdx-social:hover .mdx-social__layer:nth-child(0) {
-    transform: translateY(30px)
 }
 
 .md-banner {
@@ -447,24 +237,6 @@ th {
     max-height: none
 }
 
-/* annotation buttons' pulse animation */
 a.md-annotation__index {
     border-radius: 2.2ch;
-}
-
-@keyframes pulse {
-    0% {
-        box-shadow: 0 0 0 0 var(--md-accent-fg-color);
-        transform: scale(.95)
-    }
-
-    75% {
-        box-shadow: 0 0 0 .625em transparent;
-        transform: scale(1)
-    }
-
-    to {
-        box-shadow: 0 0 0 0 transparent;
-        transform: scale(.95)
-    }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 plugins:
+  - search
   - blog
 
 extra_css:


### PR DESCRIPTION
## Summary

- Enable MkDocs site search alongside the blog plugin.
- Remove duplicated homepage headings, trim the logo grid, and soften the open-source usage wording to avoid implying endorsements.
- Fix the copyable pre-commit YAML and add a Getting Started selection guide with minimal examples.
- Clean up unused homepage CSS and align the hero button style with the rest of the site.

## Validation

- python3 -m mkdocs build
- git diff --check