### PR TITLE
docs: add Homebrew tap as a new installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ This repository hosts the public site at <https://cpp-linter.github.io/>, includ
 
 - Project overview and landing page content
 - Getting started documentation
+- Clang tools distribution guides (static binaries, Docker images, Python wheels)
 - Discussion and community entry points

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,7 +68,9 @@ Select the method that best fits your development workflow:
 
 </div>
 
-## Clang Tools Distribution
+## Clang Tools — Simplified
+
+We provide ready-to-use **binaries**, **Docker images**, and **Python wheels** of key clang tools:
 
 <div class="grid cards" markdown>
 
@@ -76,7 +78,7 @@ Select the method that best fits your development workflow:
 
     ---
 
-    Distribution clang tools static binaries for various platforms
+    Statically-linked `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` binaries for Linux, macOS, and Windows
 
     [Download from →](https://github.com/cpp-linter/clang-tools-static-binaries){ .md-button .md-button--primary }
 
@@ -84,7 +86,7 @@ Select the method that best fits your development workflow:
 
     ---
 
-    Distribution clang tools Docker images for various platforms
+    Docker images with pre-installed `clang-format` and `clang-tidy`
 
     [Download from →](https://github.com/cpp-linter/clang-tools-docker){ .md-button .md-button--primary }
 
@@ -92,9 +94,25 @@ Select the method that best fits your development workflow:
 
     ---
 
-    Distribution clang tools Python wheels for various platforms
+    Redistribute `clang-format` and `clang-tidy` Python wheels
 
     [Download from →](https://github.com/cpp-linter/clang-tools-wheel){ .md-button .md-button--primary }
+
+- :fontawesome-brands-python: **clang-apply-replacements**
+
+    ---
+
+    Standalone Python wheel for `clang-apply-replacements`
+
+    [Download from →](https://github.com/cpp-linter/clang-apply-replacements){ .md-button .md-button--primary }
+
+- :fontawesome-brands-python: **clang-include-cleaner**
+
+    ---
+
+    Standalone Python wheel for `clang-include-cleaner` — detects unused `#include` directives
+
+    [Download from →](https://github.com/cpp-linter/clang-include-cleaner){ .md-button .md-button--primary }
 
 </div>
 
@@ -106,7 +124,7 @@ Select the method that best fits your development workflow:
 
     ---
 
-    Easy installation of clang tools static binaries via pip
+    Install `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` via static binaries or Python wheels using a single CLI
 
     [Get started with clang-tools CLI →](https://cpp-linter.github.io/clang-tools-pip/){ .md-button .md-button--primary }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,4 +136,12 @@ We provide ready-to-use **binaries**, **Docker images**, and **Python wheels** o
 
     [Get started with asdf →](https://github.com/cpp-linter/asdf-clang-tools){ .md-button .md-button--primary }
 
+- :fontawesome-brands-apple: **Homebrew Tap**
+
+    ---
+
+    Install `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` via Homebrew — no compilation required
+
+    [Get started with Homebrew →](https://github.com/cpp-linter/homebrew-tap){ .md-button .md-button--primary }
+
 </div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -102,17 +102,17 @@ We provide ready-to-use **binaries**, **Docker images**, and **Python wheels** o
 
     ---
 
-    Standalone Python wheel for `clang-apply-replacements`
+    Install `clang-apply-replacements` via pip — standalone Python wheel
 
-    [Download from →](https://github.com/cpp-linter/clang-apply-replacements){ .md-button .md-button--primary }
+    [Install from PyPI →](https://pypi.org/project/clang-apply-replacements/){ .md-button .md-button--primary }
 
 - :fontawesome-brands-python: **clang-include-cleaner**
 
     ---
 
-    Standalone Python wheel for `clang-include-cleaner` — detects unused `#include` directives
+    Install `clang-include-cleaner` via pip — detects unused `#include` directives
 
-    [Download from →](https://github.com/cpp-linter/clang-include-cleaner){ .md-button .md-button--primary }
+    [Install from PyPI →](https://pypi.org/project/clang-include-cleaner/){ .md-button .md-button--primary }
 
 </div>
 


### PR DESCRIPTION
## Summary

Add the [cpp-linter Homebrew tap](https://github.com/cpp-linter/homebrew-tap) as a new installation method in the Getting Started documentation.

## Changes

- **docs/getting-started.md** — Added a Homebrew Tap card to the "Easy Installation" grid section, alongside the existing pip and asdf options. This shows users they can install clang-format, clang-tidy, clang-query, clang-apply-replacements, and clang-include-cleaner via Homebrew with no compilation required.

## Why

The Homebrew tap provides pre-built static binaries for macOS users, making installation even easier for developers who prefer Homebrew as their package manager.

cc @shenxianpeng