### PR TITLE
docs: add shared merchandise support page

### DIFF
--- a/docs/merch.md
+++ b/docs/merch.md
@@ -1,0 +1,85 @@
+# Support cpp-linter with a T-shirt
+
+cpp-linter is **not** opening a general T-shirt store right now.
+
+Instead, we want one shared project fund so support goes to the project as a whole, not to only one maintainer. That makes it much easier to cover printing, shipping, and the occasional T-shirt thank-you gift fairly.
+
+## Why a shared fund comes first
+
+If supporters donate to individual maintainers separately, it creates an awkward problem: one person may receive the money while someone else is expected to handle the shirt, inventory, or shipping.
+
+Our preferred model is:
+
+1. Support goes into one public project account.
+2. The core maintainers manage it together.
+3. Shirt fulfillment is offered manually when budget, stock, and shipping make sense.
+
+This keeps expectations clear and avoids turning project support into private side payments.
+
+## Shared funding path
+
+!!! tip "Preferred setup"
+    Support cpp-linter through our shared Open Collective account: [opencollective.com/cpp-linter](https://opencollective.com/cpp-linter)
+
+[Support cpp-linter on Open Collective](https://opencollective.com/cpp-linter){ .md-button .md-button--primary }
+
+Why Open Collective:
+
+- It gives the project a shared public account instead of sending funds to only one person.
+- It makes incoming funds and project expenses easier to track transparently.
+- It gives the maintainers a cleaner way to share responsibility for project spending.
+
+We may still add GitHub Sponsors later, but this Open Collective page is now the **canonical shared destination** for project support.
+
+## What supporters should expect
+
+!!! important "No active checkout yet"
+    There is no public order form or direct purchase flow at the moment.
+
+If you want to support cpp-linter, the intended model is:
+
+- Donate through [Open Collective](https://opencollective.com/cpp-linter).
+- If we are offering shirts at that time, we will confirm availability manually.
+- A shirt is a **thank-you perk**, not an automatic purchase entitlement.
+
+That means fulfillment may depend on:
+
+- available stock
+- shipping destination
+- sizing availability
+- current project budget
+
+## T-shirt policy
+
+We still like the idea of project shirts, but only in a lightweight and sustainable way.
+
+Our working policy is:
+
+1. The shirt is meant to thank notable supporters of the project.
+2. We will confirm each shipment manually before collecting size and address details.
+3. We will avoid promising fulfillment unless the shared fund can cover it.
+4. Limited quantity, international shipping, and cost changes may affect availability.
+
+## If you want one
+
+The shared fund is live, and the best starting point is:
+
+- [Open Collective for cpp-linter](https://opencollective.com/cpp-linter)
+
+If you specifically want to express interest in a shirt, the best follow-up channels are:
+
+- [GitHub Discussions](https://github.com/cpp-linter/cpp-linter/discussions)
+- [Issues in this site repository](https://github.com/cpp-linter/cpp-linter.github.io/issues)
+
+If enough people are interested, we can publish a clearer supporter policy around shirt availability and supporter tiers.
+
+## Next steps
+
+The remaining rollout is:
+
+1. Add this same support link to the main repository.
+2. Publish the maintainer policy for how project funds are used.
+3. Define when a supporter may be offered a shirt.
+4. Add GitHub Sponsors later only if it still points people back to the shared funding model.
+
+Thanks for supporting cpp-linter and helping us keep the project fair for everyone involved.

--- a/docs/merch.md
+++ b/docs/merch.md
@@ -1,75 +1,23 @@
-# Support cpp-linter with a T-shirt
+# T-shirt Thank-You
 
-cpp-linter is **not** opening a general T-shirt store right now.
+We are not selling T-shirts.
 
-Instead, we want one shared project fund so support goes to the project as a whole, not to only one maintainer. That makes it much easier to cover printing, shipping, and the occasional T-shirt thank-you gift fairly.
+The T-shirt is our way of saying thank you to people who support the project. If your cumulative donations on [Open Collective](https://opencollective.com/cpp-linter) reach **USD 100**, we will reach out personally and send you one.
 
-## Shared funding path
-
-!!! tip "Preferred setup"
-    Support cpp-linter through our shared Open Collective account: [opencollective.com/cpp-linter](https://opencollective.com/cpp-linter)
+## How to support
 
 [Support cpp-linter on Open Collective](https://opencollective.com/cpp-linter){ .md-button .md-button--primary }
 
-Why Open Collective:
+All contributions go to the project as a whole — not to any single maintainer — and all income and expenses are publicly visible.
 
-- It gives the project a shared public account instead of sending funds to only one person.
-- It makes incoming funds and project expenses easier to track transparently.
-- It gives the maintainers a cleaner way to share responsibility for project spending.
+## How the T-shirt works
 
-We may still add GitHub Sponsors later, but this Open Collective page is now the **canonical shared destination** for project support.
+1. Donate through [Open Collective](https://opencollective.com/cpp-linter).
+2. When your cumulative donations reach **USD 100**, we will contact you to arrange shipping.
+3. We confirm each shipment manually and collect your size and address at that point.
 
-## What supporters should expect
+Availability depends on stock, sizing, and shipping at the time — but we will always let you know before anything is sent.
 
-!!! important "No active checkout yet"
-    There is no public order form or direct purchase flow at the moment.
+Have questions? Start a [GitHub Discussion](https://github.com/cpp-linter/cpp-linter/discussions) or open an [issue](https://github.com/cpp-linter/cpp-linter.github.io/issues).
 
-If you want to support cpp-linter, the intended model is:
-
-- Donate through [Open Collective](https://opencollective.com/cpp-linter).
-- Supporters who contribute **USD 100 or more** may be eligible for one T-shirt.
-- If we are offering shirts at that time, we will confirm availability manually.
-- A shirt is a **thank-you perk**, not an automatic purchase entitlement.
-
-That means fulfillment may depend on:
-
-- available stock
-- shipping destination
-- sizing availability
-- current project budget
-
-## T-shirt policy
-
-We still like the idea of project shirts, but only in a lightweight and sustainable way.
-
-Our working policy is:
-
-1. The shirt is meant to thank notable supporters of the project.
-2. Supporters contributing **USD 100 or more** may be considered for one shirt.
-3. We will confirm each shipment manually before collecting size and address details.
-4. We will avoid promising fulfillment unless the shared fund can cover it.
-5. Limited quantity, international shipping, and cost changes may affect availability.
-
-## If you want one
-
-The shared fund is live, and the best starting point is:
-
-- [Open Collective for cpp-linter](https://opencollective.com/cpp-linter)
-
-If you specifically want to express interest in a shirt, the best follow-up channels are:
-
-- [GitHub Discussions](https://github.com/cpp-linter/cpp-linter/discussions)
-- [Issues in this site repository](https://github.com/cpp-linter/cpp-linter.github.io/issues)
-
-This threshold is meant to cover the shirt as a thank-you gesture, along with packaging, international shipping, and platform fees.
-
-## Next steps
-
-The remaining rollout is:
-
-1. Add this same support link to the main repository.
-2. Publish the maintainer policy for how project funds are used.
-3. Define when a supporter may be offered a shirt.
-4. Add GitHub Sponsors later only if it still points people back to the shared funding model.
-
-Thanks for supporting cpp-linter and helping us keep the project fair for everyone involved.
+Thanks for supporting cpp-linter!

--- a/docs/merch.md
+++ b/docs/merch.md
@@ -4,18 +4,6 @@ cpp-linter is **not** opening a general T-shirt store right now.
 
 Instead, we want one shared project fund so support goes to the project as a whole, not to only one maintainer. That makes it much easier to cover printing, shipping, and the occasional T-shirt thank-you gift fairly.
 
-## Why a shared fund comes first
-
-If supporters donate to individual maintainers separately, it creates an awkward problem: one person may receive the money while someone else is expected to handle the shirt, inventory, or shipping.
-
-Our preferred model is:
-
-1. Support goes into one public project account.
-2. The core maintainers manage it together.
-3. Shirt fulfillment is offered manually when budget, stock, and shipping make sense.
-
-This keeps expectations clear and avoids turning project support into private side payments.
-
 ## Shared funding path
 
 !!! tip "Preferred setup"

--- a/docs/merch.md
+++ b/docs/merch.md
@@ -39,6 +39,7 @@ We may still add GitHub Sponsors later, but this Open Collective page is now the
 If you want to support cpp-linter, the intended model is:
 
 - Donate through [Open Collective](https://opencollective.com/cpp-linter).
+- Supporters who contribute **USD 100 or more** may be eligible for one T-shirt.
 - If we are offering shirts at that time, we will confirm availability manually.
 - A shirt is a **thank-you perk**, not an automatic purchase entitlement.
 
@@ -56,9 +57,10 @@ We still like the idea of project shirts, but only in a lightweight and sustaina
 Our working policy is:
 
 1. The shirt is meant to thank notable supporters of the project.
-2. We will confirm each shipment manually before collecting size and address details.
-3. We will avoid promising fulfillment unless the shared fund can cover it.
-4. Limited quantity, international shipping, and cost changes may affect availability.
+2. Supporters contributing **USD 100 or more** may be considered for one shirt.
+3. We will confirm each shipment manually before collecting size and address details.
+4. We will avoid promising fulfillment unless the shared fund can cover it.
+5. Limited quantity, international shipping, and cost changes may affect availability.
 
 ## If you want one
 
@@ -71,7 +73,7 @@ If you specifically want to express interest in a shirt, the best follow-up chan
 - [GitHub Discussions](https://github.com/cpp-linter/cpp-linter/discussions)
 - [Issues in this site repository](https://github.com/cpp-linter/cpp-linter.github.io/issues)
 
-If enough people are interested, we can publish a clearer supporter policy around shirt availability and supporter tiers.
+This threshold is meant to cover the shirt as a thank-you gesture, along with packaging, international shipping, and platform fees.
 
 ## Next steps
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Discussion: discussion.md
+  - Merchandise: merch.md
   # - Blog:
   #     - blog/index.md
 exclude_docs: |


### PR DESCRIPTION
## Why

We want the site to present project support in a way that fits cpp-linter's maintainer model. Instead of framing shirts as direct sales, this change points people to the shared Open Collective account so support goes to the project as a whole.

## What changed

- add a new `Merchandise` page to the site navigation
- introduce support-first copy that explains why a shared public fund is preferred
- link directly to the live Open Collective page as the canonical support destination
- clarify that shirts are a manual thank-you perk, not an automatic checkout flow or purchase entitlement

## Notes for review

The page intentionally avoids fixed pricing, order intake, and fulfillment promises. It keeps the shirt idea visible while setting expectations around stock, shipping, and maintainer-managed distribution.