### PR TITLE
feat(social): generate Open Graph / social card images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,11 +8,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Enable Material's social card generation for the deployed site.
+      # Environments without the native imaging libs (e.g. Netlify previews)
+      # leave this unset, so card generation is skipped there.
+      CARDS: 'true'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      - name: Install imaging system dependencies (for social cards)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 markdown-gfm-admonition
 mkdocs
 mkdocs-include-markdown-plugin
-mkdocs-material
+mkdocs-material[imaging]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ markdown_extensions:
 
 plugins:
   - search
+  - social:
+      cards: !ENV [CARDS, false]
   - blog
 
 extra_css:


### PR DESCRIPTION
## What
Enables Material's **social plugin** so every page gets an auto-generated **Open Graph / Twitter card image**. Sharing a `cpp-linter.github.io` link to GitHub, Slack, X, etc. will render a rich preview card instead of a bare URL.

## Why gated behind an env var
Card generation needs native imaging libs (Cairo & friends), which aren't available in every build environment — notably **Netlify PR previews** (configured in Netlify's UI, no `netlify.toml`). To avoid breaking those builds, the plugin is gated:

```yaml
plugins:
  - social:
      cards: !ENV [CARDS, false]   # off unless explicitly enabled
```

- **GitHub Pages deploy** (`deploy.yml`) installs the imaging system libs and sets `CARDS=true` → cards are generated for the published site.
- **Netlify previews / any other env** leave `CARDS` unset → cards are skipped → build still succeeds (previews just won't show the generated cards, which is fine for content review).

## Changes
- `mkdocs.yml` — add the `social` plugin with `cards: !ENV [CARDS, false]`.
- `docs/requirements.txt` — `mkdocs-material` → `mkdocs-material[imaging]`.
- `.github/workflows/deploy.yml` — install `libcairo2-dev` + friends and set `CARDS=true` for the build job.

## Validation
The **Deploy Documentation / build** job runs on this PR with `CARDS=true` and the imaging libs installed, so a green build here means card generation actually works (not just that the config parses).

## Note
This branch (`claude/cpp-linter-org-gaps-z9fuep`) previously carried the squash-merged #47, so the diff may also show `docs/index.md` — its content is **identical to `main`** (no functional change); only the three files above are real changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uXrN1wk5EaqK5GimN3deT)_