### PR TITLE
style: revive and style stats block in trusted-by section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -141,7 +141,7 @@ title: C/C++ Linting
     <img src="https://img.shields.io/github/stars/cpp-linter/cpp-linter-action?style=for-the-badge&logo=github&logoColor=white&label=Action%20stars&color=3f51b5" alt="GitHub stars for cpp-linter-action" loading="lazy" decoding="async">
   </a>
   <a href="https://github.com/cpp-linter/cpp-linter-action/graphs/contributors" target="_blank" rel="noopener">
-    <img src="https://img.shields.io/github/contributors/cpp-linter/cpp-linter?style=for-the-badge&logo=github&logoColor=white&label=Contributors&color=3f51b5" alt="Contributors to cpp-linter" loading="lazy" decoding="async">
+    <img src="https://img.shields.io/github/contributors/cpp-linter/cpp-linter-action?style=for-the-badge&logo=github&logoColor=white&label=Contributors&color=3f51b5" alt="Contributors to cpp-linter" loading="lazy" decoding="async">
   </a>
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,7 @@ title: C/C++ Linting
   <a href="https://github.com/cpp-linter/cpp-linter-action" target="_blank" rel="noopener">
     <img src="https://img.shields.io/github/stars/cpp-linter/cpp-linter-action?style=for-the-badge&logo=github&logoColor=white&label=Action%20stars&color=3f51b5" alt="GitHub stars for cpp-linter-action" loading="lazy" decoding="async">
   </a>
-  <a href="https://github.com/cpp-linter/cpp-linter/graphs/contributors" target="_blank" rel="noopener">
+  <a href="https://github.com/cpp-linter/cpp-linter-action/graphs/contributors" target="_blank" rel="noopener">
     <img src="https://img.shields.io/github/contributors/cpp-linter/cpp-linter?style=for-the-badge&logo=github&logoColor=white&label=Contributors&color=3f51b5" alt="Contributors to cpp-linter" loading="lazy" decoding="async">
   </a>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,20 +133,17 @@ title: C/C++ Linting
   </div>
 </div>
 
-<!-- <div class="stats-grid">
-  <div class="stat">
-    <strong>1,000+</strong>
-    <span>GitHub Users</span>
-  </div>
-  <div class="stat">
-    <strong>20K+</strong>
-    <span>Downloads/Month</span>
-  </div>
-  <div class="stat">
-    <strong>50+</strong>
-    <span>Contributors</span>
-  </div>
-</div> -->
+<div class="project-stats">
+  <a href="https://pypi.org/project/cpp-linter/" target="_blank" rel="noopener">
+    <img src="https://img.shields.io/pypi/dm/cpp-linter?style=for-the-badge&logo=pypi&logoColor=white&label=PyPI%20downloads&color=3f51b5" alt="cpp-linter downloads per month on PyPI" loading="lazy" decoding="async">
+  </a>
+  <a href="https://github.com/cpp-linter/cpp-linter-action" target="_blank" rel="noopener">
+    <img src="https://img.shields.io/github/stars/cpp-linter/cpp-linter-action?style=for-the-badge&logo=github&logoColor=white&label=Action%20stars&color=3f51b5" alt="GitHub stars for cpp-linter-action" loading="lazy" decoding="async">
+  </a>
+  <a href="https://github.com/cpp-linter/cpp-linter/graphs/contributors" target="_blank" rel="noopener">
+    <img src="https://img.shields.io/github/contributors/cpp-linter/cpp-linter?style=for-the-badge&logo=github&logoColor=white&label=Contributors&color=3f51b5" alt="Contributors to cpp-linter" loading="lazy" decoding="async">
+  </a>
+</div>
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,16 +133,19 @@ title: C/C++ Linting
   </div>
 </div>
 
-<div class="project-stats">
-  <a href="https://pypi.org/project/cpp-linter/" target="_blank" rel="noopener">
-    <img src="https://img.shields.io/pypi/dm/cpp-linter?style=for-the-badge&logo=pypi&logoColor=white&label=PyPI%20downloads&color=3f51b5" alt="cpp-linter downloads per month on PyPI" loading="lazy" decoding="async">
-  </a>
-  <a href="https://github.com/cpp-linter/cpp-linter-action" target="_blank" rel="noopener">
-    <img src="https://img.shields.io/github/stars/cpp-linter/cpp-linter-action?style=for-the-badge&logo=github&logoColor=white&label=Action%20stars&color=3f51b5" alt="GitHub stars for cpp-linter-action" loading="lazy" decoding="async">
-  </a>
-  <a href="https://github.com/cpp-linter/cpp-linter-action/graphs/contributors" target="_blank" rel="noopener">
-    <img src="https://img.shields.io/github/contributors/cpp-linter/cpp-linter-action?style=for-the-badge&logo=github&logoColor=white&label=Contributors&color=3f51b5" alt="Contributors to cpp-linter" loading="lazy" decoding="async">
-  </a>
+<div class="stats-grid">
+  <div class="stat">
+    <strong>1,000+</strong>
+    <span>GitHub Users</span>
+  </div>
+  <div class="stat">
+    <strong>20K+</strong>
+    <span>Downloads/Month</span>
+  </div>
+  <div class="stat">
+    <strong>50+</strong>
+    <span>Contributors</span>
+  </div>
 </div>
 
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -197,6 +197,26 @@ th {
     color: var(--md-default-fg-color--light);
 }
 
+/* Live project stats (real shields.io badges, not hard-coded numbers) */
+.project-stats {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.project-stats a {
+    display: inline-flex;
+    line-height: 0;
+}
+
+.project-stats img {
+    height: 38px;
+    width: auto;
+}
+
 /* Mobile responsiveness for trusted by section */
 @media screen and (max-width: 768px) {
     .logo-grid {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -197,7 +197,51 @@ th {
     color: var(--md-default-fg-color--light);
 }
 
-/* Mobile responsiveness for trusted by section */
+/* Stats grid under trusted by section */
+.stats-grid {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0;
+    margin: 2rem auto 0;
+    padding: 1.5rem 0;
+    max-width: 700px;
+}
+
+.stat {
+    flex: 1;
+    text-align: center;
+    padding: 0 2rem;
+    position: relative;
+}
+
+.stat + .stat::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10%;
+    height: 80%;
+    width: 1px;
+    background: var(--md-default-fg-color--lightest);
+}
+
+.stat strong {
+    display: block;
+    font-size: 2.2rem;
+    font-weight: 800;
+    color: var(--md-primary-fg-color);
+    line-height: 1.2;
+    margin-bottom: 0.25rem;
+}
+
+.stat span {
+    display: block;
+    font-size: 0.9rem;
+    color: var(--md-default-fg-color--light);
+    font-weight: 500;
+}
+
+/* Mobile responsiveness */
 @media screen and (max-width: 768px) {
     .logo-grid {
         grid-template-columns: repeat(2, 1fr);
@@ -205,7 +249,23 @@ th {
         padding: 0 1rem;
     }
 
+    .stats-grid {
+        flex-direction: column;
+        gap: 1.5rem;
+        padding: 1rem 0;
+    }
 
+    .stat {
+        padding: 0.5rem 0;
+    }
+
+    .stat + .stat::before {
+        display: none;
+    }
+
+    .stat strong {
+        font-size: 1.8rem;
+    }
 }
 
 /* Ensure tab items have proper contrast */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -197,26 +197,6 @@ th {
     color: var(--md-default-fg-color--light);
 }
 
-/* Live project stats (real shields.io badges, not hard-coded numbers) */
-.project-stats {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    gap: 1rem;
-    margin-top: 1rem;
-}
-
-.project-stats a {
-    display: inline-flex;
-    line-height: 0;
-}
-
-.project-stats img {
-    height: 38px;
-    width: auto;
-}
-
 /* Mobile responsiveness for trusted by section */
 @media screen and (max-width: 768px) {
     .logo-grid {


### PR DESCRIPTION
## What

The "Trusted by developers worldwide" section has a stats block that was previously commented out — and had no CSS backing it — so it never rendered.

This PR **revives the hard-coded stats block** and gives it a proper visual display with:

- **Horizontal flexbox row** — the three stats (GitHub Users, Downloads/Month, Contributors) sit side by side
- **Large, bold numbers** in the theme's indigo primary color (`var(--md-primary-fg-color)`)
- **Subtle vertical dividers** between each stat for visual separation
- **Understated labels** in muted text below each number
- **Responsive layout** — collapses to a vertical stack on mobile with no dividers

The `.stats-grid` rules in `extra.css` provide all the styling; the HTML block in `index.md` is the same mark-up as before, just uncommented.

## Why

- **Simple and clean** — the numbers are displayed prominently but fit the existing page design
- **Zero extra dependencies** — no external badge images, no shields.io calls
- **Naturally responsive** — flexbox handles mobile without extra markup
- **Matching the theme** — uses the same CSS variables as the rest of the site (indigo primary, muted light text)

## Notes

Purely a content/styling change to the home page; the surrounding "Trusted by" avatar grid is untouched.