### PR TITLE
feat: add Edit this page link to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
     - navigation.top
     - navigation.sections
     - navigation.footer
+    - content.action.edit
     - content.code.annotate
     - content.code.copy
     - content.tabs.link
@@ -87,6 +88,8 @@ plugins:
 
 extra_css:
   - stylesheets/extra.css
+
+edit_uri_template: https://github.com/cpp-linter/cpp-linter.github.io/edit/main/docs/{path}
 
 extra:
   social:


### PR DESCRIPTION
## Changes

- Enabled `content.action.edit` theme feature
- Added `edit_uri_template` — points to `https://github.com/cpp-linter/cpp-linter.github.io/edit/main/docs/{path}`

This adds an **"Edit this page"** link on every doc page, directing readers to suggest edits directly on GitHub.

## Why

- Lowers the barrier for contributions — anyone can fix a typo or improve docs with one click
- Makes the docs feel alive and community-maintained

No new dependencies, no CI changes, no plugin required.